### PR TITLE
A few idioms and a bugfix

### DIFF
--- a/spew.lisp
+++ b/spew.lisp
@@ -51,14 +51,13 @@
     (list :content html)))
 
 (defun cols-identifier () 
-  (setf *col-id* (+ 1 *col-id*))
-  *col-id*)
+  (incf *col-id*))
+
 (defun rows-identifier () 
-  (setf *row-id* (+ 1 *row-id*))
-  *row-id*)
+  (incf *row-id*))
+
 (defun custom-identifier () 
-  (setf *custom-id* (+ 1 *custom-id*))
-  *custom-id*)
+  (incf *custom-id*))
 
 (defun cols-html (cols-list) 
   (format nil "<div id='col-container-~a'>~%~{~a~%~}</div><div style='clear:both;'></div>" 

--- a/spew.lisp
+++ b/spew.lisp
@@ -16,8 +16,8 @@
 (defun simple-div-html (x) 
   (let ((css (getf x :styles)))
     (if css 
-	(progn 
-	  (setf *running-css* (cons (simple-div-css css) *running-css*))
+	(progn
+          (push (simple-div-css css) *running-css*)
 	  (format nil "<div id='custom-div-~a'>~a</div>" 
 		  *custom-id*
 		  (getf x :content)))
@@ -41,13 +41,13 @@
 (defun cols (cols-list) 
   (let ((html (cols-html cols-list))
 	(css (cols-css cols-list)))
-    (setf *running-css* (cons css *running-css*))
+    (push css *running-css*)
     (list :content html)))
 
 (defun rows (rows-list)
   (let ((html (rows-html rows-list))
 	(css (rows-css rows-list)))
-    (setf *running-css* (cons css *running-css*))
+    (push css *running-css*)
     (list :content html)))
 
 (defun cols-identifier () 

--- a/spew.lisp
+++ b/spew.lisp
@@ -8,6 +8,12 @@
 
 (defparameter *running-css* nil)
 
+(defun reset-state ()
+  (setf *col-id* 0
+        *row-id* 0
+        *custom-id* 0
+        *running-css* nil))
+
 (defun simple-div-css (css) 
   (format nil "#custom-div-~a { ~a }" 
 	  (custom-identifier)
@@ -24,19 +30,20 @@
 	(format nil "<div>~a</div>" 
 		(getf x :content)))))
 
-(defun make-files (html-content) 
-    (with-open-file (stream "test.css"
-			    :direction :output 
-			    :if-does-not-exist :create
-			    :if-exists :overwrite)
-      (format stream "~{~a~%~}" *running-css*))
-    (with-open-file (stream "test.html" 
-			    :direction :output
-			    :if-does-not-exist :create
-			    :if-exists :overwrite) 
-      (format stream 
-	      "<html><head><link href='test.css' rel='stylesheet' type='text/css'></head><body>~a</body></html>"
-	      (getf html-content :content))))
+(defun make-files (html-content)
+  (reset-state)
+  (with-open-file (stream "test.css"
+                          :direction :output 
+                          :if-does-not-exist :create
+                          :if-exists :overwrite)
+    (format stream "~{~a~%~}" *running-css*))
+  (with-open-file (stream "test.html" 
+                          :direction :output
+                          :if-does-not-exist :create
+                          :if-exists :overwrite) 
+    (format stream 
+            "<html><head><link href='test.css' rel='stylesheet' type='text/css'></head><body>~a</body></html>"
+            (getf html-content :content))))
 
 (defun cols (cols-list) 
   (let ((html (cols-html cols-list))


### PR DESCRIPTION
Because the IDs and CSS accumulator are globals, running make-files (via example) a second time doubled up the CSS. These should be reset on each run.
